### PR TITLE
Viewer opens in vi, also syntax editor turned on for edit mode (needed for macos)

### DIFF
--- a/pkg/components/editor/editor.go
+++ b/pkg/components/editor/editor.go
@@ -70,6 +70,36 @@ func (e Editor) InsertDoc() tea.Cmd {
 	return modal.DisplayDocInsertModal(editedDoc)
 }
 
+func (e Editor) ViewDoc() tea.Cmd {
+	doc := e.engine.GetSelectedDocumentMarshalled()
+	if err != nil {
+		return modal.DisplayErrorModal(err)
+	}
+
+	if err := e.openFileInViewer(doc); err != nil {
+		return modal.DisplayErrorModal(err)
+	}
+
+	return nil
+}
+
+func (e Editor) openFileInViewer(doc []byte) error {
+	file := filepath.Join(os.TempDir(), "mongoView.json")
+	if err := os.WriteFile(file, doc, 0600); err != nil {
+		return fmt.Errorf("failed to write file to allow for doc viewing: %w", err)
+	}
+	defer os.Remove(file)
+
+	openViewerCmd := exec.Command("vi", "-M", "-c", "syntax on", "-c", "set syntax=json", file)
+	openViewerCmd.Stdout = os.Stdout
+	openViewerCmd.Stdin = os.Stdin
+	openViewerCmd.Stderr = os.Stderr
+	// Ignore the error here as vi -M returns 1 if the user tries to edit the file
+	_ = openViewerCmd.Run()
+
+	return nil
+}
+
 func (e Editor) openFileInEditor(doc []byte) ([]byte, error) {
 	file := filepath.Join(os.TempDir(), "mongoEdit.json")
 	if err := os.WriteFile(file, doc, 0600); err != nil {
@@ -78,10 +108,13 @@ func (e Editor) openFileInEditor(doc []byte) ([]byte, error) {
 	defer os.Remove(file)
 
 	editor := os.Getenv("EDITOR")
+	var args []string
 	if editor == "" {
 		editor = "vi"
+		args = []string{"-c", "syntax on", "-c", "set syntax=json"}
 	}
-	openEditorCmd := exec.Command(editor, file)
+	args = append(args, file)
+	openEditorCmd := exec.Command(editor, args...)
 	openEditorCmd.Stdout = os.Stdout
 	openEditorCmd.Stdin = os.Stdin
 	openEditorCmd.Stderr = os.Stderr

--- a/pkg/components/editor/editor.go
+++ b/pkg/components/editor/editor.go
@@ -71,7 +71,7 @@ func (e Editor) InsertDoc() tea.Cmd {
 }
 
 func (e Editor) ViewDoc() tea.Cmd {
-	doc := e.engine.GetSelectedDocumentMarshalled()
+	doc, err := e.engine.GetSelectedDocumentMarshalled()
 	if err != nil {
 		return modal.DisplayErrorModal(err)
 	}

--- a/pkg/mainview/mainview.go
+++ b/pkg/mainview/mainview.go
@@ -82,9 +82,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.state.IsComponentActive(state.DbColTable) {
 			m.dbColTable.Focus()
 		} else if m.state.IsComponentActive(state.SingleDocViewer) {
-			if err := m.singleDocViewer.Focus(); err != nil {
-				return m, modal.DisplayErrorModal(err)
-			}
+			cmd = m.singleDocEditor.ViewDoc()
+			m.state.SetActiveComponent(state.DocList)
+			cmds = append(cmds, cmd, tea.ClearScreen)
 		} else if m.state.IsComponentActive(state.SingleDocEditor) {
 			cmd = m.singleDocEditor.EditDoc()
 			m.state.SetActiveComponent(state.DocList)


### PR DESCRIPTION
I kept getting thrown by the fact that editing a doc had a different flow to viewing one, and also struggled to navigate large documents without search.

Hence, this PR!

Now, "v" opens the file in a read-only, buffer-locked version of `vi`.  It also forces syntax highlighting on by default for both the viewer and the editor.  (On default macOS vi, syntax highlighting is off by default.)

There may be a neater way to do this (what happens if they set `EDITOR` to something other than vi/vim?  What if the user actually wants syntax highlighting to be off for whatever reason?) but for now, this is a start that seems to work well!